### PR TITLE
Test sampling

### DIFF
--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -174,7 +174,6 @@ def test_linear_vpsde():
     x = np.random.normal(size=(n, n_features))
 
     # Define SDE
-    y = alpha * x + np.random.normal(size=(n, n_features)) * gamma * x
     beta_min = 0.01
     beta_max = 20
     N = 100
@@ -233,7 +232,6 @@ def test_linear_subvpsde():
     x = np.random.normal(size=(n, n_features))
 
     # Define SDE
-    y = alpha * x + np.random.normal(size=(n, n_features)) * gamma * x
     beta_min = 0.01
     beta_max = 20
     N = 100
@@ -274,8 +272,3 @@ def test_linear_subvpsde():
 
     assert diff_mean.mean() < 0.1, f"subVPSDE: diff_mean.mean() = {diff_mean.mean()}"
     assert diff_std.mean() < 0.1, f"subVPSDE: diff_std.mean() = {diff_std.mean()}"
-
-
-test_linear_vesde()
-test_linear_vpsde()
-test_linear_subvpsde()


### PR DESCRIPTION
I added the tests to the VPSDE and subVPSDE classes.

This includes:
- extending the score function to include VPSDE and subVPSDE;
- renaming beta to gamma, to avoid confusion with parameters of VPSDE and subVPSDE;
- evaluating std estimates w.r.t. to "true" std rather than "effective" std.

~~The threshold on the std estimates to pass the test was raised to 1. Under VESDE, the std estimates are biased by a factor of sigma_min, so it makes sense that they differ a bit from the true std. Under VPSDE and subVPSDE, there should be no bias, yet the std estimates differ quite a bit from the true std.~~
