### PR TITLE
support future annotations in python3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,15 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-numpy = "^1.21"
+python = "^3.9"
+numpy = "^1.24"
 jaxtyping = "^0.2.19"
 einops = "^0.8.0"
-scipy = "^1.10"
+scipy = "^1.13"
 tqdm = "^4.66.4"
 lightgbm = "^4.3.0"
 ml-collections = "^0.1.1"
-scikit-learn = "^1.3.0"
+scikit-learn = "^1.5.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.2.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ ignore = [
     "F722", # Syntax error (issue with jaxtyping)
     "F821", # Issue with jax typing
     "PT006", # flake8-pytest-style fixture-final-use
+    "UP037", # do not remove quotes around annotations (when __future__.annotations is imported)
 ]
 line-length = 95
 lint.select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,15 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
-numpy = "^1.24"
+python = "^3.8"
+numpy = "^1.21"
 jaxtyping = "^0.2.19"
 einops = "^0.8.0"
-scipy = "^1.13.1"
+scipy = "^1.10"
 tqdm = "^4.66.4"
 lightgbm = "^4.3.0"
 ml-collections = "^0.1.1"
-scikit-learn = "^1.5.0"
+scikit-learn = "^1.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.2.2"

--- a/src/treeffuser/_base_tabular_diffusion.py
+++ b/src/treeffuser/_base_tabular_diffusion.py
@@ -1,14 +1,8 @@
-"""
-This should be the main file corresponding to the project.
-"""
+from __future__ import annotations
 
 import abc
 import warnings
-from typing import List
 from typing import Literal
-from typing import Optional
-from typing import Tuple
-from typing import Union
 
 import einops
 import numpy as np
@@ -98,13 +92,11 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
 
     def _validate_data(
         self,
-        X: Optional[ndarray] = None,
-        y: Optional[ndarray] = None,
+        X: ndarray | None = None,
+        y: ndarray | None = None,
         validate_X: bool = True,
         validate_y: bool = True,
-    ) -> Tuple[
-        Optional[Float[ndarray, "batch x_dim"]], Optional[Float[ndarray, "batch y_dim"]]
-    ]:
+    ) -> tuple[Float[ndarray, "batch x_dim"] | None, Float[ndarray, "batch y_dim"] | None]:
         """Reshape X and/or y to adhere to the (batch, n_dim) convention, and cast them as flows."""
         if validate_X and X is not None:
             X = _check_array(X)
@@ -118,7 +110,7 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
         self,
         X: Float[ndarray, "batch x_dim"],
         y: Float[ndarray, "batch y_dim"],
-        cat_idx: Optional[List[int]] = None,
+        cat_idx: list[int] | None = None,
     ):
         """
         Fit the conditional diffusion model to the tabular data (X, y).
@@ -393,9 +385,9 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
         self,
         X: Float[ndarray, "batch x_dim"],
         n_samples: int = 100,
-        bandwidth: Union[float, Literal["scott", "silverman"]] = 1.0,
+        bandwidth: float | Literal["scott", "silverman"] = 1.0,
         verbose: bool = False,
-    ) -> List[KernelDensity]:
+    ) -> list[KernelDensity]:
         """
         Estimate the distribution of the predicted responses for the given input data `X` using Gaussian
         KDEs from `sklearn.neighbors.KernelDensity`.
@@ -448,7 +440,7 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
         X: Float[ndarray, "batch x_dim"],
         y: Float[ndarray, "batch y_dim"],
         n_samples: int = 10,
-        bandwidth: Union[float, Literal["scott", "silverman"]] = 1.0,
+        bandwidth: float | Literal["scott", "silverman"] = 1.0,
         verbose: bool = False,
     ) -> float:
         """
@@ -490,7 +482,7 @@ class BaseTabularDiffusion(BaseEstimator, abc.ABC):
         X: Float[ndarray, "batch x_dim"],
         y: Float[ndarray, "batch y_dim"],
         n_samples: int = 10,
-        bandwidth: Union[float, Literal["scott", "silverman"]] = 1.0,
+        bandwidth: float | Literal["scott", "silverman"] = 1.0,
         verbose: bool = False,
     ) -> float:
         y_samples = self._sample_without_validation(X=X, n_samples=n_samples, verbose=verbose)

--- a/src/treeffuser/sde/base_sde.py
+++ b/src/treeffuser/sde/base_sde.py
@@ -67,7 +67,7 @@ class ReverseSDE(BaseSDE):
         sde: BaseSDE,
         t_reverse_origin: float,
         score_fn: Callable[
-            [Float[ndarray, "batch y_dim"], Float[ndarray, batch]], Float[ndarray, batch]
+            [Float[ndarray, "batch y_dim"], Float[ndarray, "batch"]], Float[ndarray, "batch"]
         ],
     ):
         self.sde = sde

--- a/src/treeffuser/sde/base_sde.py
+++ b/src/treeffuser/sde/base_sde.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 from typing import Callable
 
@@ -65,7 +67,7 @@ class ReverseSDE(BaseSDE):
         sde: BaseSDE,
         t_reverse_origin: float,
         score_fn: Callable[
-            [Float[ndarray, "batch y_dim"], Float[ndarray, "batch"]], Float[ndarray, "batch"]
+            [Float[ndarray, "batch y_dim"], Float[ndarray, batch]], Float[ndarray, batch]
         ],
     ):
         self.sde = sde

--- a/src/treeffuser/sde/diffusion_sdes.py
+++ b/src/treeffuser/sde/diffusion_sdes.py
@@ -54,7 +54,7 @@ class DiffusionSDE(BaseSDE):
     @abc.abstractmethod
     def sample_from_theoretical_prior(
         self, shape: tuple[int, ...], seed: int | None = None
-    ) -> Float[ndarray, *shape]:
+    ) -> Float[ndarray, "*shape"]:
         """
         Sample from the theoretical distribution that p_T(y) converges to.
 

--- a/src/treeffuser/sde/diffusion_sdes.py
+++ b/src/treeffuser/sde/diffusion_sdes.py
@@ -1,8 +1,6 @@
+from __future__ import annotations
+
 import abc
-from typing import Dict
-from typing import Optional
-from typing import Type
-from typing import Union
 
 import numpy as np
 from jaxtyping import Float
@@ -44,7 +42,7 @@ class DiffusionSDE(BaseSDE):
         return 1.0
 
     @abc.abstractmethod
-    def get_hyperparams(self) -> Dict:
+    def get_hyperparams(self) -> dict:
         """
         Return a dictionary with the hyperparameters of the SDE.
 
@@ -55,8 +53,8 @@ class DiffusionSDE(BaseSDE):
 
     @abc.abstractmethod
     def sample_from_theoretical_prior(
-        self, shape: tuple[int, ...], seed: Optional[int] = None
-    ) -> Float[ndarray, "*shape"]:
+        self, shape: tuple[int, ...], seed: int | None = None
+    ) -> Float[ndarray, *shape]:
         """
         Sample from the theoretical distribution that p_T(y) converges to.
 
@@ -114,7 +112,7 @@ class DiffusionSDE(BaseSDE):
         """
 
         def kernel_density_fn(
-            y: Float[ndarray, "batch_ y_dim"], t: Union[float, Float[np.ndarray, "batch_ 1"]]
+            y: Float[ndarray, "batch_ y_dim"], t: float | Float[np.ndarray, "batch_ 1"]
         ):
             if isinstance(t, float):
                 t = np.ones_like(y) * t
@@ -159,7 +157,7 @@ def _register_diffusion_sde(name: str):
     return _register
 
 
-def get_diffusion_sde(name: Optional[str] = None) -> Union[Type[DiffusionSDE], dict]:
+def get_diffusion_sde(name: str | None = None) -> type[DiffusionSDE] | dict:
     """
     Function to retrieve a registered diffusion SDE by its name.
 
@@ -237,9 +235,7 @@ class VESDE(DiffusionSDE):
 
     def drift_and_diffusion(
         self, y: Float[ndarray, "batch y_dim"], t: Float[ndarray, "batch 1"]
-    ) -> Union[
-        tuple[Float[ndarray, "batch y_dim"], float, Float[ndarray, "batch y_dim"], float]
-    ]:
+    ) -> tuple[Float[ndarray, "batch y_dim"], float, Float[ndarray, "batch y_dim"], float]:
         hyperparam = self.hyperparam_schedule(t)
         hyperparam_prime = self.hyperparam_schedule.get_derivative(t)
         drift = 0.0
@@ -247,7 +243,7 @@ class VESDE(DiffusionSDE):
         return drift, diffusion
 
     def sample_from_theoretical_prior(
-        self, shape: tuple[int, ...], seed: Optional[int] = None
+        self, shape: tuple[int, ...], seed: int | None = None
     ) -> Float[ndarray, "batch x_dim y_dim"]:
         # This assumes that hyperparam_max is large enough
         rng = np.random.default_rng(seed)
@@ -328,7 +324,7 @@ class VPSDE(DiffusionSDE):
         return drift, diffusion
 
     def sample_from_theoretical_prior(
-        self, shape: tuple[int, ...], seed: Optional[int] = None
+        self, shape: tuple[int, ...], seed: int | None = None
     ) -> Float[ndarray, "batch x_dim y_dim"]:
         # Assume that hyperparam_max is large enough so that the SDE has converged to N(0,1).
         rng = np.random.default_rng(seed)
@@ -411,7 +407,7 @@ class SubVPSDE(DiffusionSDE):
         return drift, diffusion
 
     def sample_from_theoretical_prior(
-        self, shape: tuple[int, ...], seed: Optional[int] = None
+        self, shape: tuple[int, ...], seed: int | None = None
     ) -> Float[ndarray, "batch x_dim y_dim"]:
         # Assume that hyperparam_max is large enough so that the SDE has converged to N(0,1).
         rng = np.random.default_rng(seed)

--- a/src/treeffuser/treeffuser.py
+++ b/src/treeffuser/treeffuser.py
@@ -1,7 +1,6 @@
-from typing import List
+from __future__ import annotations
+
 from typing import Literal
-from typing import Optional
-from typing import Union
 
 from treeffuser._base_tabular_diffusion import BaseTabularDiffusion
 from treeffuser._score_models import LightGBMScoreModel
@@ -15,7 +14,7 @@ class Treeffuser(BaseTabularDiffusion):
         self,
         n_repeats: int = 30,
         n_estimators: int = 3000,
-        early_stopping_rounds: Optional[int] = 50,
+        early_stopping_rounds: int | None = 50,
         eval_percent: float = 0.1,
         num_leaves: int = 31,
         max_depth: int = -1,
@@ -28,11 +27,11 @@ class Treeffuser(BaseTabularDiffusion):
         n_jobs: int = -1,
         sde_name: str = "vesde",
         sde_initialize_from_data: bool = False,
-        sde_hyperparam_min: Optional[Union[float, Literal["default"]]] = None,
-        sde_hyperparam_max: Optional[Union[float, Literal["default"]]] = None,
-        seed: Optional[int] = None,
+        sde_hyperparam_min: float | Literal["default"] | None = None,
+        sde_hyperparam_max: float | Literal["default"] | None = None,
+        seed: int | None = None,
         verbose: int = 0,
-        extra_lightgbm_params: Optional[dict] = None,
+        extra_lightgbm_params: dict | None = None,
     ):
         """
         n_repeats : int
@@ -139,7 +138,7 @@ class Treeffuser(BaseTabularDiffusion):
         return score_model
 
     @property
-    def n_estimators_true(self) -> List[int]:
+    def n_estimators_true(self) -> list[int]:
         """
         The number of estimators that are actually used in the models (after early stopping),
         one for each dimension of the score (i.e. the dimension of y).


### PR DESCRIPTION
I initially attempted to support python 3.8 but we decided that it is too outdated.
Doing so, I imported `annotations` from `__future__` in the different files, which let us simplify the annotations, even in python 3.9.